### PR TITLE
Typo in configuration example

### DIFF
--- a/man/udisks-glue.conf.5
+++ b/man/udisks-glue.conf.5
@@ -112,7 +112,7 @@ filter disks {
 
 filter burnable {
     optical = true
-    disc_closed = false
+    optical_disc_closed = false
 }
 
 filter optical {


### PR DESCRIPTION
Hi, I just fixed a typo in the second configuration example.
